### PR TITLE
FIX: Removed dead messages link from navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,6 +14,9 @@
         <li class="nav-item active">
           <%= link_to current_user.email, "#", class: "nav-link" %>
         </li>
+        <li class="nav-item active">
+          <%= link_to "< Email", "#", class: "nav-link" %>
+        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/syrashid", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,9 +14,6 @@
         <li class="nav-item active">
           <%= link_to current_user.email, "#", class: "nav-link" %>
         </li>
-        <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
-        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/syrashid", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">


### PR DESCRIPTION
Description:
Modified the navbar to be extremely clear

No Tests Needed
Don't need to run bundle or yarn

<img width="1433" alt="Screen Shot 2020-11-23 at 12 57 30 AM" src="https://user-images.githubusercontent.com/6656014/99920887-e0e45680-2d26-11eb-9887-dc41130fd05d.png">
